### PR TITLE
- change .update_tab_path to be relative if path = "." for ukb_df

### DIFF
--- a/R/ukb_dataset.R
+++ b/R/ukb_dataset.R
@@ -206,8 +206,8 @@ ukb_df_field <- function(fileset, path = ".", data.pos = 2, as.lookup = FALSE) {
 
   # Update path to tab file in R source
   if(path == ".") {
-    tab_location <- file.path(getwd(), tab_file)
-    r_location <- file.path(getwd(), r_file)
+    tab_location <- tab_file
+    r_location <- r_file
   } else {
     tab_location <- file.path(path, tab_file)
     r_location <- file.path(path, r_file)


### PR DESCRIPTION
In `.update_tab_path` (see https://github.com/kenhanscombe/ukbtools/compare/master...muschellij2:master#diff-a2fd55d43d2ab8edef24e51768910caeL209), if the path is set using `getwd()`, then this script will fail in the future run if the files are moved.  Without adding in `getwd()`, then this script should work in the future.